### PR TITLE
fix bug of spliting SUN397 dataset

### DIFF
--- a/scripts/split_dataset.py
+++ b/scripts/split_dataset.py
@@ -40,7 +40,12 @@ for split in ["train", "val", "val_on_train"]:
             os.mkdir(class_dir)
         if args.dataset_name == "SUN397":
             prefix = class_name[0]
-            shutil.copyfile(dataset_root / dataset_prefix[args.dataset_name] / prefix / class_name / img_path.name, class_dir / img_path.name)
+            class_name_map = {}
+            with open(dataset_root/"ClassName.txt", 'r') as f:
+                for line in f:
+                    line = line[3:].strip()
+                    class_name_map[line.replace('/', '_')] = line
+            shutil.copyfile(dataset_root / dataset_prefix[args.dataset_name] / prefix / class_name_map[class_name] / img_path.name, class_dir / img_path.name)
         else:
             try:
                 shutil.copyfile(dataset_root / dataset_prefix[args.dataset_name] / class_name / img_path.name, class_dir / img_path.name)


### PR DESCRIPTION
Previously while spliting SUN397 dataset, we have some class names like "stadium_football" "hangar_indoor" in _train_data.txt_, but the corresponding path is actually folded, for example "stadium/football" "hangar/indoor", causing data loading error.

By referring to _ClassName.txt_ that comes along with SUM397 dataset, we can build a map and avoid such path/class_name conflict.